### PR TITLE
fix(azure-openai): handle unsupported temperature parameter and retry with default value

### DIFF
--- a/examples/_azure_check.py
+++ b/examples/_azure_check.py
@@ -6,6 +6,7 @@ import os
 import re
 import sys
 from pathlib import Path
+from urllib.parse import urlparse
 
 
 def _load_from_zshrc() -> None:
@@ -28,14 +29,19 @@ def _load_from_zshrc() -> None:
         pass
 
 
-def check_azure_connection(model: str, api_version: str | None = None) -> None:
-    """Verify Azure env vars are set and the model responds.
+def check_azure_connection(
+    model: str,
+    api_version: str | None = None,
+    extra_models: list[str] | None = None,
+) -> None:
+    """Verify Azure env vars are set and every model responds.
 
     Resolution order for env vars:
       1. Current process environment (already set in shell)
       2. ~/.zshrc export statements (fallback for uv run / non-login shells)
 
-    Exits with a clear error message if the check fails.
+    Pass ``extra_models`` to check additional models (e.g. the subcall model)
+    after the primary model.  Exits with a clear error message if any check fails.
     """
     # --- 1. Load missing vars from ~/.zshrc ---
     _load_from_zshrc()
@@ -75,11 +81,11 @@ def check_azure_connection(model: str, api_version: str | None = None) -> None:
     print(f"  env endpoint : {endpoint_env}")
     print(f"  resolved URL : {adapter.endpoint}")
     print(f"  api key      : {key_preview}")
-    print(f"  model        : {model}")
 
-    # Pre-resolve hostname to catch DNS issues early
+    all_models = [model] + (extra_models or [])
+
+    # Pre-resolve hostname once (shared across all models)
     import socket
-    from urllib.parse import urlparse
 
     try:
         hostname = urlparse(adapter.endpoint).hostname
@@ -92,27 +98,37 @@ def check_azure_connection(model: str, api_version: str | None = None) -> None:
         print(f"  hostname DNS : FAILED ({e})")
         sys.exit(1)
 
-    print(f"Checking connection ...", end=" ", flush=True)
+    # --- 4. Minimal API call per model ---
+    import httpx
 
-    # --- 4. Minimal API call ---
-    try:
-        import httpx
-        resp = adapter.complete(
-            [{"role": "user", "content": "Reply with the single word: ok"}],
-            max_tokens=100,  # GPT-5.1 needs headroom before emitting content
-            temperature=0.0,
-        )
-        adapter.close()
-        answer = (resp.text or "").strip().lower()
-        if not answer:
-            print("FAILED (empty response — model returned no content)")
+    for m in all_models:
+        print(f"  model        : {m}")
+        try:
+            m_adapter = AzureOpenAIAdapter(model=m, timeout=30.0)
+        except EnvironmentError as exc:
+            print(f"ERROR: {exc}")
             sys.exit(1)
-        print(f"OK  ✓  (response: {answer!r})\n")
-    except httpx.HTTPStatusError as exc:
-        print(f"FAILED")
-        print(f"  HTTP {exc.response.status_code}: {exc.response.text[:300]}")
-        sys.exit(1)
-    except Exception as exc:
-        print(f"FAILED")
-        print(f"  {type(exc).__name__}: {exc}")
-        sys.exit(1)
+
+        print(f"Checking connection for {m!r} ...", end=" ", flush=True)
+        try:
+            resp = m_adapter.complete(
+                [{"role": "user", "content": "Reply with the single word: ok"}],
+                max_tokens=100,
+                temperature=0.0,
+            )
+            m_adapter.close()
+            answer = (resp.text or "").strip().lower()
+            if not answer:
+                print("FAILED (empty response — model returned no content)")
+                sys.exit(1)
+            print(f"OK  ✓  (response: {answer!r})")
+        except httpx.HTTPStatusError as exc:
+            print("FAILED")
+            print(f"  HTTP {exc.response.status_code}: {exc.response.text[:300]}")
+            sys.exit(1)
+        except Exception as exc:
+            print("FAILED")
+            print(f"  {type(exc).__name__}: {exc}")
+            sys.exit(1)
+
+    print()

--- a/src/pyrlm_runtime/adapters/azure_openai.py
+++ b/src/pyrlm_runtime/adapters/azure_openai.py
@@ -16,30 +16,33 @@ logger = logging.getLogger(__name__)
 def _azure_payload_builder(
     messages: list[dict[str, str]],
     max_tokens: int,
-    temperature: float,
+    temperature: float | None,
     model: str | None,
 ) -> dict[str, object]:
     """Classic deployment-URL style: model is in the URL, not the body."""
     del model
-    return {
+    payload: dict[str, object] = {
         "messages": messages,
-        "temperature": temperature,
         "max_completion_tokens": max_tokens,
     }
+    if temperature is not None:
+        payload["temperature"] = temperature
+    return payload
 
 
 def _azure_v1_payload_builder(
     messages: list[dict[str, str]],
     max_tokens: int,
-    temperature: float,
+    temperature: float | None,
     model: str | None,
 ) -> dict[str, object]:
     """OpenAI v1-compat style: model goes in the request body."""
     payload: dict[str, object] = {
         "messages": messages,
-        "temperature": temperature,
         "max_completion_tokens": max_tokens,
     }
+    if temperature is not None:
+        payload["temperature"] = temperature
     if model:
         payload["model"] = model
     return payload
@@ -123,18 +126,21 @@ class AzureOpenAIAdapter(ModelAdapter):
             payload_builder=payload_builder,
             timeout=timeout,
         )
-        # Set to True after detecting that this model rejects custom temperature.
+        # Populated on first detection of a temperature-related 400.
         # Avoids a wasted round-trip on every subsequent call.
+        # None  → omit the field entirely (unsupported_parameter)
+        # float → send that fixed value (unsupported_value, e.g. 1.0)
         self._temperature_unsupported = False
+        self._temperature_fallback: float | None = 1.0
 
     def complete(
         self,
         messages: list[dict[str, str]],
         *,
         max_tokens: int = 512,
-        temperature: float = 0.0,
+        temperature: float | None = 0.0,
     ) -> ModelResponse:
-        effective_temp = 1.0 if self._temperature_unsupported else temperature
+        effective_temp = self._temperature_fallback if self._temperature_unsupported else temperature
         try:
             return self._adapter.complete(
                 messages, max_tokens=max_tokens, temperature=effective_temp
@@ -149,21 +155,29 @@ class AzureOpenAIAdapter(ModelAdapter):
                 msg = err.get("message", "")
             except Exception:
                 raise exc
-            # Some reasoning models (e.g. gpt-5.x) reject any temperature other
-            # than the API default (1.0).  Detect, log, and retry once.
-            if code in ("unsupported_parameter", "unsupported_value") and (
-                param == "temperature" or "temperature" in msg
-            ):
-                logger.info(
-                    "Model %s does not support temperature=%s; retrying with temperature=1.0",
-                    self.model,
-                    effective_temp,
-                )
-                self._temperature_unsupported = True
-                return self._adapter.complete(
-                    messages, max_tokens=max_tokens, temperature=1.0
-                )
-            raise
+            is_temperature_error = param == "temperature" or "temperature" in msg
+            if not is_temperature_error:
+                raise
+            if code == "unsupported_parameter":
+                # Model does not accept the temperature field at all — omit it.
+                fallback: float | None = None
+            elif code == "unsupported_value":
+                # Model accepts temperature but only the default (1.0).
+                fallback = 1.0
+            else:
+                raise
+            logger.info(
+                "Model %s rejected temperature=%s (code=%s); retrying with temperature=%s",
+                self.model,
+                effective_temp,
+                code,
+                fallback,
+            )
+            self._temperature_unsupported = True
+            self._temperature_fallback = fallback
+            return self._adapter.complete(
+                messages, max_tokens=max_tokens, temperature=fallback
+            )
 
     def close(self) -> None:
         self._adapter.close()

--- a/src/pyrlm_runtime/adapters/azure_openai.py
+++ b/src/pyrlm_runtime/adapters/azure_openai.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+import logging
 import os
 import re
 from urllib.parse import urlparse
 
+import httpx
+
 from .base import ModelAdapter, ModelResponse
 from .generic_chat import GenericChatAdapter
+
+logger = logging.getLogger(__name__)
 
 
 def _azure_payload_builder(
@@ -118,6 +123,9 @@ class AzureOpenAIAdapter(ModelAdapter):
             payload_builder=payload_builder,
             timeout=timeout,
         )
+        # Set to True after detecting that this model rejects custom temperature.
+        # Avoids a wasted round-trip on every subsequent call.
+        self._temperature_unsupported = False
 
     def complete(
         self,
@@ -126,7 +134,36 @@ class AzureOpenAIAdapter(ModelAdapter):
         max_tokens: int = 512,
         temperature: float = 0.0,
     ) -> ModelResponse:
-        return self._adapter.complete(messages, max_tokens=max_tokens, temperature=temperature)
+        effective_temp = 1.0 if self._temperature_unsupported else temperature
+        try:
+            return self._adapter.complete(
+                messages, max_tokens=max_tokens, temperature=effective_temp
+            )
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code != 400:
+                raise
+            try:
+                err = exc.response.json().get("error", {})
+                code = err.get("code", "")
+                param = err.get("param", "")
+                msg = err.get("message", "")
+            except Exception:
+                raise exc
+            # Some reasoning models (e.g. gpt-5.x) reject any temperature other
+            # than the API default (1.0).  Detect, log, and retry once.
+            if code in ("unsupported_parameter", "unsupported_value") and (
+                param == "temperature" or "temperature" in msg
+            ):
+                logger.info(
+                    "Model %s does not support temperature=%s; retrying with temperature=1.0",
+                    self.model,
+                    effective_temp,
+                )
+                self._temperature_unsupported = True
+                return self._adapter.complete(
+                    messages, max_tokens=max_tokens, temperature=1.0
+                )
+            raise
 
     def close(self) -> None:
         self._adapter.close()

--- a/src/pyrlm_runtime/adapters/generic_chat.py
+++ b/src/pyrlm_runtime/adapters/generic_chat.py
@@ -13,7 +13,7 @@ from .base import ModelAdapter, ModelResponse, Usage, estimate_usage
 
 logger = logging.getLogger(__name__)
 
-PayloadBuilder = Callable[[list[dict[str, str]], int, float, str | None], dict[str, Any]]
+PayloadBuilder = Callable[[list[dict[str, str]], int, "float | None", str | None], dict[str, Any]]
 ResponseParser = Callable[[dict[str, Any]], tuple[str, Usage | None]]
 
 
@@ -106,14 +106,15 @@ def _extract_response_meta(data: dict[str, Any]) -> dict[str, Any]:
 def default_payload_builder(
     messages: list[dict[str, str]],
     max_tokens: int,
-    temperature: float,
+    temperature: float | None,
     model: str | None,
 ) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "messages": messages,
         "max_tokens": max_tokens,
-        "temperature": temperature,
     }
+    if temperature is not None:
+        payload["temperature"] = temperature
     if model:
         payload["model"] = model
     return payload
@@ -282,7 +283,7 @@ class GenericChatAdapter(ModelAdapter):
         messages: list[dict[str, str]],
         *,
         max_tokens: int = 512,
-        temperature: float = 0.0,
+        temperature: float | None = 0.0,
     ) -> ModelResponse:
         payload = self.payload_builder(messages, max_tokens, temperature, self.model)
         last_error: Exception | None = None


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Azure OpenAI integration to gracefully handle unsupported temperature parameters. When the API reports temperature as unsupported, the system now automatically retries with a compatible default temperature, ensuring requests complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->